### PR TITLE
Add ParallelInputsSink

### DIFF
--- a/DataStreams/GuardedBlockOutputStream.h
+++ b/DataStreams/GuardedBlockOutputStream.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <DataStreams/IBlockOutputStream.h>
+#include <DataStreams/IBlockStream_fwd.h>
+
+#include <mutex>
+
+namespace AH
+{
+
+class GuardedBlockOutputStream : public IBlockOutputStream
+{
+public:
+    GuardedBlockOutputStream(BlockOutputStreamPtr stream_) : stream(stream_) { }
+
+    Block getHeader() const override
+    {
+        std::lock_guard lock(mutex);
+        return stream->getHeader();
+    }
+
+    void write(const Block & block) override
+    {
+        std::lock_guard lock(mutex);
+        stream->write(block);
+    }
+
+    void writePrefix() override
+    {
+        std::lock_guard lock(mutex);
+        stream->writePrefix();
+    }
+
+    void writeSuffix() override
+    {
+        std::lock_guard lock(mutex);
+        stream->writeSuffix();
+    }
+
+    void flush() override
+    {
+        std::lock_guard lock(mutex);
+        stream->flush();
+    }
+
+private:
+    BlockOutputStreamPtr stream;
+    mutable std::mutex mutex;
+};
+
+}

--- a/DataStreams/IBlockOutputStream.h
+++ b/DataStreams/IBlockOutputStream.h
@@ -1,0 +1,44 @@
+// The code in this file is based on original ClickHouse source code
+// which is licensed under Apache license v2.0
+// See: https://github.com/ClickHouse/ClickHouse/
+
+#pragma once
+#include "arrow_clickhouse_types.h"
+
+#include <DataStreams/IBlockStream_fwd.h>
+
+
+namespace AH
+{
+
+
+/** Interface of stream for writing data
+  */
+class IBlockOutputStream // : private boost::noncopyable
+{
+public:
+    IBlockOutputStream() {}
+
+    /** Get data structure of the stream in a form of "header" block (it is also called "sample block").
+      * Header block contains column names, data types, columns of size 0. Constant columns must have corresponding values.
+      * You must pass blocks of exactly this structure to the 'write' method.
+      */
+    virtual Block getHeader() const = 0;
+
+    /** Write block.
+      */
+    virtual void write(const Block & block) = 0;
+
+    /** Write or do something before all data or after all data.
+      */
+    virtual void writePrefix() {}
+    virtual void writeSuffix() {}
+
+    /** Flush output buffers if any.
+      */
+    virtual void flush() {}
+
+    virtual ~IBlockOutputStream() {}
+};
+
+}

--- a/DataStreams/IBlockStream_fwd.h
+++ b/DataStreams/IBlockStream_fwd.h
@@ -1,7 +1,3 @@
-// The code in this file is based on original ClickHouse source code
-// which is licensed under Apache license v2.0
-// See: https://github.com/ClickHouse/ClickHouse/
-
 #pragma once
 
 #include <memory>


### PR DESCRIPTION
A push-like streams MT model:

1. Threads are running in ParallelInputsProcessor
2. They could be limited by max IO threads in ParallelInputsStream on semaphore (TODO)
3. Results are written into output stream via sink (locked by mutex or semaphore)

The bonus is the same thread makes all the operations with Block from reading to writing.